### PR TITLE
correcting typos in en-GB.json

### DIFF
--- a/en-GB.json
+++ b/en-GB.json
@@ -274,8 +274,8 @@
 				}
 			},
 			"about": "Premium gives you access to more panels, statistics, a custom bot and more! Visit our [website](https://ticketsbot.net/premium) to find out more.",
-			"already_activated": "Good news! Premium is already active in in this server.",
-			"already_activated_whitelabel": "Good news! Premium is already active in in this server.\r\n\r\nFor help getting started with whitelabel, read [our whitelabel setup guide](https://docs.ticketsbot.net/premium/whitelabel-setup-guide)."
+			"already_activated": "Good news! Premium is already active in this server.",
+			"already_activated_whitelabel": "Good news! Premium is already active in this server.\r\n\r\nFor help getting started with whitelabel, read [our whitelabel setup guide](https://docs.ticketsbot.net/premium/whitelabel-setup-guide)."
 		}
 	},
 	"generic": {


### PR DESCRIPTION
## Issue:

`premium[already_activated]` and `premium[already_activated_whitelabel]` had x2 `in`'s in the message values.

<img width="522" alt="Screenshot 2023-06-27 at 9 02 39 AM" src="https://github.com/TicketsBot/locale/assets/71395931/5d7371b9-d5e1-4272-8b90-b692fbe6b313">

---

## Resolution

deleting extra `in`'s in the messaging